### PR TITLE
UX: fix header for showcased category boxes

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -62,6 +62,7 @@ $topic-height: 70;
     margin-bottom: 1em;
     > .topic-list-header,
     .posts-map,
+    .num.posts,
     .num.views,
     .category {
       display: none;


### PR DESCRIPTION
Before:

<img width="1123" alt="Screenshot 2021-12-09 at 21 03 29" src="https://user-images.githubusercontent.com/11170663/145426603-e57682ef-9378-43ee-8f23-d255b64adba1.png">

After:

<img width="1124" alt="Screenshot 2021-12-09 at 21 03 08" src="https://user-images.githubusercontent.com/11170663/145426592-39322ed7-0314-4453-89d0-9d61afddd605.png">